### PR TITLE
Upgrade jest-puppeteer

### DIFF
--- a/puppeteer/package-lock.json
+++ b/puppeteer/package-lock.json
@@ -15,7 +15,7 @@
             "@types/puppeteer": ">=2.1.5",
             "dotenv": ">=8.2.0",
             "jest": "^29.7.0",
-            "jest-puppeteer": "^10.1.4",
+            "jest-puppeteer": "^11.0.0",
             "merge": ">=1.2.1",
             "mysql": ">=2.18.1",
             "puppeteer": "^24.28.0",
@@ -3496,12 +3496,12 @@
          }
       },
       "node_modules/expect-puppeteer": {
-         "version": "10.1.4",
-         "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.1.4.tgz",
-         "integrity": "sha512-zNVzk/+TkPS/CuTlGSK7SjXuUpQiakXtUJhbTRrcPHop4jCWydPx9RlvHhQELzZYgXlLhIP+hvBzUNiN8WNAow==",
+         "version": "11.0.0",
+         "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-11.0.0.tgz",
+         "integrity": "sha512-fgxsbOD+HqwOCMitYqEDzRoJM2fxKbCKPYfUoukK+qdZm/nC+cTOI74Au2MfmMZmF/5CgQGO4+1Ywq2GgD8zCQ==",
          "license": "MIT",
          "engines": {
-            "node": ">=16"
+            "node": ">=18"
          }
       },
       "node_modules/extract-zip": {
@@ -4948,21 +4948,21 @@
          }
       },
       "node_modules/jest-dev-server": {
-         "version": "10.1.4",
-         "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.1.4.tgz",
-         "integrity": "sha512-bGQ6sedNGtT6AFHhCVqGTXMPz7UyJi/ZrhNBgyqsP0XU9N8acCEIfqZEA22rOaZ+NdEVsaltk6tL7UT6aXfI7w==",
+         "version": "11.0.0",
+         "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-11.0.0.tgz",
+         "integrity": "sha512-a54rw3uEzsPckyiXo2rPji9R/5z0d0qhXtru+NwCP8cDxOFk/BIP9PNgmcLh0DU8UTl8s6Lg1u+ri5uQsTJTmw==",
          "license": "MIT",
          "dependencies": {
             "chalk": "^4.1.2",
             "cwd": "^0.10.0",
             "find-process": "^1.4.7",
             "prompts": "^2.4.2",
-            "spawnd": "^10.1.4",
+            "spawnd": "^11.0.0",
             "tree-kill": "^1.2.2",
             "wait-on": "^8.0.1"
          },
          "engines": {
-            "node": ">=16"
+            "node": ">=18"
          }
       },
       "node_modules/jest-diff": {
@@ -5261,19 +5261,19 @@
          "license": "MIT"
       },
       "node_modules/jest-environment-puppeteer": {
-         "version": "10.1.4",
-         "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.1.4.tgz",
-         "integrity": "sha512-cx2jzf1qZb6/vdmLbRccF0k/zSsoWlrXi8bg10GzrODxiwsRomVDszTfoOCRsQ+C1sbJ+ubI1PlryIvvYjITrA==",
+         "version": "11.0.0",
+         "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-11.0.0.tgz",
+         "integrity": "sha512-BJR+k19/awJmXVc5IJ3VY+tho0888PvHAp16D+DP/ezRL84bgg4ggc1Q3mfa85DI+Nw9hgTme3pt0X5F7CWxmg==",
          "license": "MIT",
          "dependencies": {
             "chalk": "^4.1.2",
             "cosmiconfig": "^8.3.6",
             "deepmerge": "^4.3.1",
-            "jest-dev-server": "^10.1.4",
+            "jest-dev-server": "^11.0.0",
             "jest-environment-node": "^29.7.0"
          },
          "engines": {
-            "node": ">=16"
+            "node": ">=18"
          }
       },
       "node_modules/jest-environment-puppeteer/node_modules/@jest/schemas": {
@@ -5569,16 +5569,16 @@
          }
       },
       "node_modules/jest-puppeteer": {
-         "version": "10.1.4",
-         "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.1.4.tgz",
-         "integrity": "sha512-I9bADDn9EzpaL9QgzEtyJhd29PBv45rZJFPROUC2KWZHUs+5OGjzBOZKBzmqECdGv2GV/JL+NMdjqRJde2A36Q==",
+         "version": "11.0.0",
+         "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-11.0.0.tgz",
+         "integrity": "sha512-kixkUTNcXikldQ+TusIEvqtTO/et/MiXGkoUBQViPSdSN6JOPvTjDN/mo6Jh4EJzay8qFg/Sd4v4gPS0y9b+zw==",
          "license": "MIT",
          "dependencies": {
-            "expect-puppeteer": "^10.1.4",
-            "jest-environment-puppeteer": "^10.1.4"
+            "expect-puppeteer": "^11.0.0",
+            "jest-environment-puppeteer": "^11.0.0"
          },
          "engines": {
-            "node": ">=16"
+            "node": ">=18"
          },
          "peerDependencies": {
             "puppeteer": ">=19"
@@ -7654,16 +7654,16 @@
          }
       },
       "node_modules/spawnd": {
-         "version": "10.1.4",
-         "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.1.4.tgz",
-         "integrity": "sha512-drqHc0mKJmtMsiGMOCwzlc5eZ0RPtRvT7tQAluW2A0qUc0G7TQ8KLcn3E6K5qzkLkH2UkS3nYQiVGULvvsD9dw==",
+         "version": "11.0.0",
+         "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-11.0.0.tgz",
+         "integrity": "sha512-brBHv9HYi8lwNvbI7X52NDZe4yAdsQwvr81b/r98LaN82LzeEnQ0L6YXBvG25zhgWRadTwB+4GsUu9NrNQcVzw==",
          "license": "MIT",
          "dependencies": {
             "signal-exit": "^4.1.0",
             "tree-kill": "^1.2.2"
          },
          "engines": {
-            "node": ">=16"
+            "node": ">=18"
          }
       },
       "node_modules/spawnd/node_modules/signal-exit": {

--- a/puppeteer/package.json
+++ b/puppeteer/package.json
@@ -10,7 +10,7 @@
       "@types/puppeteer": ">=2.1.5",
       "dotenv": ">=8.2.0",
       "jest": "^29.7.0",
-      "jest-puppeteer": "^10.1.4",
+      "jest-puppeteer": "^11.0.0",
       "merge": ">=1.2.1",
       "mysql": ">=2.18.1",
       "puppeteer": "^24.28.0",


### PR DESCRIPTION
This pull request updates several Puppeteer-related testing dependencies to their latest major versions (v11), and increases the minimum required Node.js version for these dependencies to 18. These changes help ensure compatibility with the latest features and security updates in the testing stack.

Dependency upgrades and compatibility:

* Upgraded `jest-puppeteer`, `expect-puppeteer`, `jest-dev-server`, `jest-environment-puppeteer`, and `spawnd` to version 11.0.0 in both `package.json` and `package-lock.json`, ensuring the test environment uses the latest versions. [[1]](diffhunk://#diff-69bc3244bb81f47cbd81ed0fbf66331a1ff0f7a7af530dd850516ae16cb6a5faL13-R13) [[2]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L18-R18) [[3]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L3499-R3504) [[4]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L4951-R4965) [[5]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L5264-R5276) [[6]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L5572-R5581) [[7]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L7657-R7666)

* Increased the minimum required Node.js version for these dependencies from 16 to 18, aligning with upstream package requirements and improving support for modern Node.js features. [[1]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L3499-R3504) [[2]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L4951-R4965) [[3]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L5264-R5276) [[4]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L5572-R5581) [[5]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L7657-R7666)