### PR TITLE
Upgrade typeorm-fixture-cli

### DIFF
--- a/puppeteer/package-lock.json
+++ b/puppeteer/package-lock.json
@@ -21,8 +21,8 @@
             "puppeteer": "^24.28.0",
             "reflect-metadata": "^0.1.14",
             "ts-jest": "^29.4.5",
-            "typeorm": ">=0.3.26",
-            "typeorm-fixtures-cli": "4.0.0",
+            "typeorm": "^0.3.27",
+            "typeorm-fixtures-cli": "4.1.0",
             "typescript": ">=4.9.0"
          }
       },
@@ -6928,9 +6928,9 @@
          }
       },
       "node_modules/typeorm-fixtures-cli": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/typeorm-fixtures-cli/-/typeorm-fixtures-cli-4.0.0.tgz",
-         "integrity": "sha512-AHymSkNQngnUG2dUwg0249H6v3WLASPzfvJUWjA8C6qYWKAEqJdZehjmvkzXQrKW4zwBs4JgEuq7c9OhpqOLrQ==",
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/typeorm-fixtures-cli/-/typeorm-fixtures-cli-4.1.0.tgz",
+         "integrity": "sha512-v+3bw741UNr0D1JyZKv42ygtPTZmXevN00Zyvi4p29ChBM1i67I4SltaIKhG8d+XH7KzsGnrKad+drajMX4ZMw==",
          "hasInstallScript": true,
          "license": "MIT",
          "dependencies": {

--- a/puppeteer/package.json
+++ b/puppeteer/package.json
@@ -16,8 +16,8 @@
       "puppeteer": "^24.28.0",
       "reflect-metadata": "^0.1.14",
       "ts-jest": "^29.4.5",
-      "typeorm": ">=0.3.26",
-      "typeorm-fixtures-cli": "4.0.0",
+      "typeorm": "^0.3.27",
+      "typeorm-fixtures-cli": "4.1.0",
       "typescript": ">=4.9.0"
    },
    "scripts": {


### PR DESCRIPTION
This pull request updates two dependencies in the Puppeteer project to newer versions, ensuring compatibility and access to the latest features and fixes.

Dependency updates:

* Upgraded `typeorm` from version `>=0.3.26` to `^0.3.27` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-69bc3244bb81f47cbd81ed0fbf66331a1ff0f7a7af530dd850516ae16cb6a5faL19-R20) [[2]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L24-R25)
* Upgraded `typeorm-fixtures-cli` from version `4.0.0` to `4.1.0` in both `package.json` and `package-lock.json`, including updated package metadata and integrity hash. [[1]](diffhunk://#diff-69bc3244bb81f47cbd81ed0fbf66331a1ff0f7a7af530dd850516ae16cb6a5faL19-R20) [[2]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L24-R25) [[3]](diffhunk://#diff-193eb1c80b5cd824bd735f20e8cd86201e2116702dc9eb8ff8ab4e7bb3cea1c4L6931-R6933)