### PR TITLE
Fix bug that compose.test.yml doesn't work

### DIFF
--- a/compose.test.yml
+++ b/compose.test.yml
@@ -34,7 +34,7 @@ services:
   playwright:
     build:
       context: playwright
-    command: bash -c "sleep 10 && npm test"
+    command: bash -c "sleep 10 && uv run pytest"
     depends_on:
       - wordpress
     environment:


### PR DESCRIPTION
This pull request makes a minor update to the `playwright` service in the `compose.test.yml` file, switching the test command from `npm test` to `uv run pytest`. This change likely reflects a move from a Node.js-based test runner to a Python-based one.